### PR TITLE
modify nginx conf for bigger uploads + manifest

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,6 +12,11 @@ location __PATH__/ {
     proxy_pass                         http://127.0.0.1:__PORT__;
     proxy_redirect                     http:// https://;
 
+    # set client body size to 500 MB
+    # Allows to upload zip file up to 500 MB
+    # See https://github.com/YunoHost-Apps/airsonic_ynh/issues/4
+    client_max_body_size 500M;
+
     # Include SSOWAT user panel.
     include conf.d/yunohost_panel.conf.inc;
 #    proxy_set_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' www.gstatic.com; img-src 'self' *.akamaized.net; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; frame-src 'self'; object-src 'none'";

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Airsonic is an open source, web-based media server.",
         "fr": "Airsonic est un server multimedia open-source."
     },
-    "version": "10.3.1~ynh1",
+    "version": "10.3.1~ynh2",
     "url": "http://airsonic.github.io",
     "license": "GPL-3.0-or-later",
     "maintainer": {


### PR DESCRIPTION
## Problem
- https://github.com/YunoHost-Apps/airsonic_ynh/issues/4

## Solution
- Modify Nginx to allow upload of bigger files (500MB)

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : 
[![Build Status](https://ci-apps.yunohost.org/jenkins/job/airsonic_ynh%20PR6-/badge/icon)](https://ci-apps.yunohost.org/jenkins/job/airsonic_ynh%20PR6/)  

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
