### PR TITLE
[buster] openjdk-8-jre doesn't exist on buster, request openjdk-11-jre instead

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="openjdk-8-jre ffmpeg"
+pkg_dependencies="openjdk-8-jre|openjdk-11-jre ffmpeg"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem

Install fails on buster because openjdk-8-jre doesn't exist

## Solution

Request either openjdk-8-jre or openjdk-11-jre to keep backward compatibility

N.B. : not tested

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

