### PR TITLE
Use commit id that has buster dependencies

### DIFF
--- a/check_process
+++ b/check_process
@@ -12,7 +12,7 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		upgrade=1        from_commit=2a0dd05780f58cb2590c05eabab3669381ac65ce
+		upgrade=1        from_commit=72d530415c016b23b6ba62085272957b04d2cca6
 		backup_restore=1
 		multi_instance=1
 		incorrect_path=1

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Stream and manage your music collection",
         "fr": "Streamez et gérez votre collection de musique"
     },
-    "version": "10.5.0~ynh2",
+    "version": "10.5.0~ynh3",
     "url": "http://airsonic.github.io",
     "license": "GPL-3.0-or-later",
     "maintainer": {


### PR DESCRIPTION
so buster CI will not complain about missing dependencies

## Problem
- Fix https://github.com/YunoHost-Apps/airsonic_ynh/issues/24

## Solution
- *And how do you fix that problem*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/airsonic_ynh%20PR-NUM-/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/airsonic_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
