### PR TITLE
Fix last DSub releases not able to connect with LDAP

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -17,7 +17,14 @@ location __PATH__/ {
     # See https://github.com/YunoHost-Apps/airsonic_ynh/issues/4
     client_max_body_size 500M;
 
+    # Fix last DSub releases not able to connect with LDAP
+    # See https://github.com/airsonic/airsonic/issues/260
+    sub_filter_types text/xml application/json;
+    sub_filter_once off;
+    sub_filter 'subsonic' 'madsonic';
+    
     # Include SSOWAT user panel.
-    include conf.d/yunohost_panel.conf.inc;
+    # Removed since sub_filter_once directive is also used in this file
+#    include conf.d/yunohost_panel.conf.inc;
 #    proxy_set_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' www.gstatic.com; img-src 'self' *.akamaized.net; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src 'self' fonts.gstatic.com; frame-src 'self'; object-src 'none'";
 }


### PR DESCRIPTION
SSOWAT user panel has been disable since it contains also a sub_filter_once directive

## Problem
- DSub v. 5.5.2 has been recently pushed to F-Droid instead of v 5.0.3 with a lot of change but it's now not able to connect to Airsonic server when LDAP is used as set here in yunohost package.
See https://github.com/airsonic/airsonic/issues/260 for details.

## Solution
- The changes use sub_filter directive to make the server think it's madsonic and use old auth method.

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [ ] **Approval (LGTM)**  
*Code review and approval have to be from a member of @YunoHost/apps group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/airsonic_ynh%20PR-NUM-/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/airsonic_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
